### PR TITLE
[TRA-80] 공용 Tab 컴포넌트 리팩터링 & 오류 수정

### DIFF
--- a/apps/web/src/app/(needLogin)/mypage/badge/[slug]/page.tsx
+++ b/apps/web/src/app/(needLogin)/mypage/badge/[slug]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { atom, useAtom, useAtomValue } from 'jotai';
 import Image from 'next/image';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 import { mypageNavConfig } from '@/constants';
 import { badgeAtom } from '@/store/mypage.atoms';
@@ -13,11 +13,12 @@ const isOneHowToAtom = atom(false);
 
 const MyPageTabs = () => {
   const pathname = usePathname();
-  const slug = pathname.split('/').pop();
   const basePath = pathname.replace(/\/[^/]+$/, '');
   const navTitle = mypageNavConfig.nav.find(
     (nav) => nav.href === basePath
   ).title;
+  const params = useSearchParams();
+  const slug = params.get('filter');
 
   const badges = useAtomValue(badgeAtom);
   const currentBadge = badges.find((badge) => badge.slug === slug);

--- a/apps/web/src/app/(needLogin)/mypage/badge/layout.tsx
+++ b/apps/web/src/app/(needLogin)/mypage/badge/layout.tsx
@@ -1,34 +1,32 @@
 'use client';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+
+import { useSetAtom } from 'jotai';
+import { useEffect } from 'react';
 
 import { Tab } from '@/components';
 import { badgeConfig } from '@/constants';
+import { selectTabAtom } from '@/store/tab.atoms';
 
 export default function BagdeLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const paths = [
-    '/mypage/badge',
-    ...badgeConfig.badges.map((badge) => `/mypage/badge/${badge.slug}`),
-  ];
+  const selectTab = useSetAtom(selectTabAtom);
+
+  useEffect(() => {
+    selectTab('all'); // 첫번째 탭을 활성화하기 위해 selectTab을 호출합니다.
+  }, [selectTab]);
+
+  const tabsWithAll = [{ slug: 'all', title: 'ALL' }, ...badgeConfig.badges];
 
   return (
     <div className='mb-14'>
       <div className='ml-5 mt-10 flex w-full items-end justify-end space-x-[-30px]'>
-        {paths.map((path, index) => (
-          <Tab
-            key={index}
-            bgColor={pathname === path ? 'white' : 'primaryGray-200'}
-            zIndex={pathname === path ? '10' : '0'}
-          >
-            <Link href={path}>
-              {index === 0 ? 'ALL' : badgeConfig.badges[index - 1].title}
-            </Link>
-          </Tab>
+        {tabsWithAll.map((badgeConfig, index) => (
+          <div key={index}>
+            <Tab slug={badgeConfig.slug}>{badgeConfig.title}</Tab>
+          </div>
         ))}
       </div>
       {children}

--- a/apps/web/src/app/(needLogin)/mypage/like_story/page.tsx
+++ b/apps/web/src/app/(needLogin)/mypage/like_story/page.tsx
@@ -1,12 +1,12 @@
 'use client';
-import { useAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 
 import { Tab } from '@/components';
 import { likeStoryConfig } from '@/constants';
-import { currentTabAtom } from '@/store/tab.atoms';
+import { selectTabAtom } from '@/store/tab.atoms';
 
-// import materialIcon from '@/utils/materialIcon';
 import { MyPageContainer } from '../_components';
 import { ViewStory } from './_components';
 import { LikeStory } from './_components/LikesStory/LikesStory';
@@ -14,49 +14,27 @@ import { LikeStory } from './_components/LikesStory/LikesStory';
 const LikeStoryPage = () => {
   // const router = useRouter();
   const params = useSearchParams();
-  const filter = params.get('filter');
+  const filter = params.get('filter') || '';
+  const selectTab = useSetAtom(selectTabAtom);
 
-  const [currentTab] = useAtom(currentTabAtom);
-  // const [draftTab] = useAtom(draftTabAtom);
+  useEffect(() => {
+    selectTab(filter);
+  }, [selectTab, filter]);
 
   return (
     <div>
       <div className='ml-5 mt-10 flex w-full items-end justify-end space-x-[-30px]'>
-        {likeStoryConfig.map((path, index) => {
-          // const isSelected =
-          //   filter === path.query || (!filter && path.tabName === 'LIKES');
-          // const isLikes = path.tabName === 'LIKES';
-          // const handleNavigation = () => {
-          //   router.push(
-          //     isLikes
-          //       ? '/mypage/like_story'
-          //       : `/mypage/like_story?filter=${path.query}`
-          //   );
-          // };
-
-          return (
-            <Tab
-              key={index}
-              bgColor={currentTab.color}
-              zIndex={currentTab.zIndex}
-            >
-              {/* icon을 넣으면 Tab의 p태그 children hydration 에러가 남. Tab부분을 수정해야할 거 같음 */}
-              {/* <div className='flex items-center' onClick={handleNavigation}>
-                {materialIcon({
-                  iconName: isLikes ? 'favorite' : 'visibility',
-                  size: 16,
-                  style: 'mr-1',
-                })}
-                <Link href={'/'}>{path.tabName}</Link>
-              </div> */}
-              {path.tabName}
-            </Tab>
-          );
-        })}
+        {likeStoryConfig.map((config, index) => (
+          <div key={index}>
+            <Tab slug={config.query}>{config.slug}</Tab>
+          </div>
+        ))}
       </div>
       <div className='text-primaryBlue-700 mb-14 ml-10 flex w-full flex-col items-center justify-center'>
         <MyPageContainer title='관심 스토리'>
-          <div className='px-12'>{filter ? <ViewStory /> : <LikeStory />}</div>
+          <div className='px-12'>
+            {filter === 'views' ? <ViewStory /> : <LikeStory />}
+          </div>
         </MyPageContainer>
       </div>
     </div>

--- a/apps/web/src/app/(needLogin)/mypage/my_story/_components/Tabs/Tabs.tsx
+++ b/apps/web/src/app/(needLogin)/mypage/my_story/_components/Tabs/Tabs.tsx
@@ -1,22 +1,25 @@
 'use client';
 
-import { useAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 
 import { Tab } from '@/components';
-import { currentTabAtom, draftTabAtom } from '@/store/tab.atoms';
+import { selectTabAtom } from '@/store/tab.atoms';
 
 export const Tabs = () => {
-  const [currentTab] = useAtom(currentTabAtom);
-  const [draftTab] = useAtom(draftTabAtom);
+  const selectTab = useSetAtom(selectTabAtom);
+  const params = useSearchParams();
+  const filter = params.get('filter') || 'travel';
+
+  useEffect(() => {
+    selectTab(filter);
+  }, [selectTab, filter]);
 
   return (
     <div className='mr-10 mt-10 flex w-full items-end justify-end space-x-[-30px]'>
-      <Tab bgColor={currentTab.color} zIndex={currentTab.zIndex}>
-        여행 기록
-      </Tab>
-      <Tab bgColor={draftTab.color} zIndex={draftTab.zIndex}>
-        임시 저장 기록
-      </Tab>
+      <Tab slug='travel'>여행 기록</Tab>
+      <Tab slug='draft'>임시 저장 기록</Tab>
     </div>
   );
 };

--- a/apps/web/src/app/(needLogin)/mypage/visit_country/layout.tsx
+++ b/apps/web/src/app/(needLogin)/mypage/visit_country/layout.tsx
@@ -1,34 +1,33 @@
 'use client';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+
+import { useSetAtom } from 'jotai';
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 
 import { Tab } from '@/components';
 import { visitedContriesConfig } from '@/constants/visited_contries.contstants';
+import { selectTabAtom } from '@/store/tab.atoms';
 
 export default function VistedContriesLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const pathArray = pathname.split('/');
-  const lastElement = pathArray[pathArray.length - 1];
+  const selectTab = useSetAtom(selectTabAtom);
+  const params = useSearchParams();
+  const filter = params.get('filter') || 'continent';
+
+  useEffect(() => {
+    selectTab(filter);
+  }, [selectTab, filter]);
 
   return (
     <div>
       <div className='ml-5 mt-10 flex w-full items-end justify-end space-x-[-30px]'>
         {visitedContriesConfig.tabs.map((tab, index) => (
-          <Tab
-            key={index}
-            bgColor={
-              lastElement === tab.lastPathname ? 'white' : 'primaryGray-200'
-            }
-            zIndex={lastElement === tab.lastPathname ? '10' : '0'}
-          >
-            <Link href={`/mypage/visit_country/${tab.lastPathname}`}>
-              {tab.tabTitle}
-            </Link>
-          </Tab>
+          <div key={index}>
+            <Tab slug={tab.lastPathname}>{tab.tabTitle}</Tab>
+          </div>
         ))}
       </div>
       {children}

--- a/apps/web/src/components/Tab/Tab.tsx
+++ b/apps/web/src/components/Tab/Tab.tsx
@@ -1,30 +1,53 @@
 'use client';
-import { useSetAtom } from 'jotai';
 
-import { tabSelectedAtom } from '@/store/tab.atoms';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { usePathname, useRouter } from 'next/navigation';
+
+import { selectTabAtom, tabStateFamily } from '@/store/tab.atoms';
+import materialIcon from '@/utils/materialIcon';
 
 import { TabProps } from './Tab.types';
 
-export const Tab = ({ children, bgColor, zIndex }: TabProps) => {
+export const Tab = ({ children, slug }: TabProps) => {
+  const pathName = usePathname();
+  const router = useRouter();
+  const selectTab = useSetAtom(selectTabAtom);
+  const tabState = useAtomValue(tabStateFamily(slug));
+  const handleTabClick = () => {
+    selectTab(slug);
+    router.push(`${pathName}?filter=${slug}`);
+    if (slug === '') router.push(`${pathName}`);
+    if (pathName.includes('/mypage/visit_country')) {
+      router.push(`/mypage/visit_country/${slug}`);
+    }
+  };
+
+  const bgColorClass = tabState.state ? 'bg-white' : 'bg-primaryGray-200';
+  const zIndexClass = tabState.state ? 'z-10' : 'z-0';
+
   const shadowStyle = {
     boxShadow:
       '0px -5px 10px -3px rgba(0, 0, 0, 0.1), 10px 0px 20px -3px rgba(0, 0, 0, 0.1)',
   };
 
-  const handleTabSelect = useSetAtom(tabSelectedAtom);
+  const islikeStoryPage = pathName === '/mypage/like_story';
+  const isLike = slug === 'LIKES';
 
   return (
     <div
-      style={{ zIndex }}
-      onClick={() => {
-        handleTabSelect();
-      }}
+      onClick={handleTabClick}
       className='text-primaryGray-400 flex w-[150px] cursor-pointer items-center justify-center overflow-hidden rounded-tr-[10px] font-bold '
     >
       <div
         style={shadowStyle}
-        className={`bg-${bgColor} hover:bg-primaryGray-300 border-primaryGray-200 flex h-[40px] w-[320px] translate-x-[30px] skew-x-[-20deg] transform items-center justify-center rounded-tl-[12px] border border-b-white transition-all duration-300 hover:text-black`}
+        className={`${bgColorClass} ${zIndexClass} hover:bg-primaryGray-300 border-primaryGray-200 flex h-[40px] w-[320px] translate-x-[30px] skew-x-[-20deg] transform items-center justify-center rounded-tl-[12px] border border-b-white transition-all duration-300 hover:text-black`}
       >
+        {islikeStoryPage &&
+          materialIcon({
+            iconName: isLike ? 'favorite' : 'visibility',
+            size: 16,
+            style: 'mr-1 skew-x-[+20deg]',
+          })}
         <p className='mr-7 skew-x-[+20deg] transform text-[14px]'>{children}</p>
       </div>
     </div>

--- a/apps/web/src/components/Tab/Tab.types.ts
+++ b/apps/web/src/components/Tab/Tab.types.ts
@@ -3,7 +3,8 @@ import { ReactNode } from 'react';
 export interface TabProps {
   children: ReactNode;
   // eslint-disable-next-line no-unused-vars
-  current?: string;
-  bgColor: string;
-  zIndex: string;
+  slug: string;
+  tabTitle?: string;
+  bgColor?: string;
+  zIndex?: string;
 }

--- a/apps/web/src/constants/like_story.constants.ts
+++ b/apps/web/src/constants/like_story.constants.ts
@@ -1,10 +1,10 @@
 export const likeStoryConfig = [
   {
-    tabName: 'LIKES',
+    slug: 'LIKES',
     query: '',
   },
   {
-    tabName: 'VIEWS',
+    slug: 'VIEWS',
     query: 'views',
   },
 ];

--- a/apps/web/src/store/tab.atoms.ts
+++ b/apps/web/src/store/tab.atoms.ts
@@ -1,44 +1,20 @@
 import { atom } from 'jotai';
+import { atomFamily } from 'jotai/utils';
 
-export const currentTabAtom = atom({
-  state: true,
-  color: 'white',
-  zIndex: '9',
-  param: 'current',
-});
-export const draftTabAtom = atom({
-  state: false,
-  color: 'primaryGray-200',
-  zIndex: '1',
-  param: 'draft',
-});
+export const tabStateFamily = atomFamily(() =>
+  atom({
+    state: false,
+  })
+);
 
-export const tabSelectedAtom = atom(null, (get, set) => {
-  if (get(currentTabAtom).state === true) {
-    set(currentTabAtom, {
-      ...get(currentTabAtom),
-      state: false,
-      color: 'primaryGray-200',
-      zIndex: '1',
-    });
-    set(draftTabAtom, {
-      ...get(draftTabAtom),
-      state: true,
-      color: 'white',
-      zIndex: '9',
-    });
-  } else {
-    set(currentTabAtom, {
-      ...get(currentTabAtom),
-      state: true,
-      color: 'white',
-      zIndex: '9',
-    });
-    set(draftTabAtom, {
-      ...get(draftTabAtom),
-      state: false,
-      color: 'primaryGray-200',
-      zIndex: '1',
-    });
+export const activeTabSlugAtom = atom('');
+
+export const selectTabAtom = atom(null, (get, set, selectedSlug: string) => {
+  const currentActiveSlug = get(activeTabSlugAtom);
+
+  if (currentActiveSlug !== selectedSlug) {
+    set(tabStateFamily(currentActiveSlug), { state: false });
   }
+  set(tabStateFamily(selectedSlug), { state: true });
+  set(activeTabSlugAtom, selectedSlug);
 });


### PR DESCRIPTION
## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 기타

## 작업 상세 내용
- 마이페이지 전체에서 사용 가능하도록 공용 Tab 컴포넌트 리팩터링하였습니다.

## 다음 할 일
- 회원가입 페이지 리팩터링

## 체크 리스트

- [x] dev 브랜치 pull 받기
- [x] dev에 merge 하기
- [x] 아직 작업 중인 파일은 올리지 않기

## 질문 사항

💬 **질문이 있어요!**

🔴 **이건 반드시 확인해 주세요!**
탭 적용 방법 예시
```
     {visitedContriesConfig.tabs.map((tab, index) => (
          <div key={index}>
            <Tab slug={tab.lastPathname}>{tab.tabTitle}</Tab>
          </div>
     ))}
```
Tab에 filter로 전달할 쿼리 스트링을 slug로 전달해주시면 아래처럼 탭이 활성화되고 주소가 변경됩니다.
<img width="1132" alt="스크린샷 2023-11-09 오후 11 40 16" src="https://github.com/mobi-community/mobi-1th-tramory/assets/123868471/7ee02a68-25ed-48b5-b89d-4da40ead8168">

방문 국가의 경우 filter가 아닌 '/mypage/visit_country/${slug}' 경로로 이동하도록 하였습니다!
<img width="1178" alt="스크린샷 2023-11-09 오후 11 41 10" src="https://github.com/mobi-community/mobi-1th-tramory/assets/123868471/211dd2d1-a579-49ba-943a-8cf726c913c9">

